### PR TITLE
Remove isEqualTo from docs

### DIFF
--- a/src/Spec/Claim.elm
+++ b/src/Spec/Claim.elm
@@ -185,9 +185,9 @@ For example:
 
     [ 1, 2, 3 ]
       |> Spec.Claim.isListWhere
-          [ Spec.Claim.isEqualTo Debug.toString 1
-          , Spec.Claim.isEqualTo Debug.toString 27
-          , Spec.Claim.isEqualTo Debug.toString 3
+          [ Spec.Claim.isEqual Debug.toString 1
+          , Spec.Claim.isEqual Debug.toString 27
+          , Spec.Claim.isEqual Debug.toString 3
           ]
 
 would result in a rejected claim, since 2 is not equal to 27.

--- a/src/Spec/Http.elm
+++ b/src/Spec/Http.elm
@@ -141,7 +141,7 @@ then the following claim would be accepted:
     Spec.Http.body
       (Spec.Http.asJson <|
         Json.Decode.field "sport" Json.Decode.string)
-      (Spec.Claim.isEqualTo Debug.toString "bowling")
+      (Spec.Claim.isEqual Debug.toString "bowling")
  
 -}
 body : HttpRequestDataAssertion a -> Claim a -> Claim HttpRequest
@@ -175,7 +175,7 @@ named `fun-image.png`, then the following claim would be accepted:
     Spec.Http.bodyPart "image" Spec.Http.asFile <|
       Spec.Claim.isListWhere
         [ Spec.Claim.specifyThat File.name <|
-            Spec.Claim.isEqualTo Debug.toString "fun-image.png"
+            Spec.Claim.isEqual Debug.toString "fun-image.png"
         ]
 
 -}
@@ -258,7 +258,7 @@ then the following claim would be accepted:
     Spec.Http.body
       (Spec.Http.asJson <|
         Json.Decode.field "sport" Json.Decode.string)
-      (Spec.Claim.isEqualTo Debug.toString "bowling")
+      (Spec.Claim.isEqual Debug.toString "bowling")
 
 -}
 asJson : Json.Decoder a -> HttpRequestDataAssertion a


### PR DESCRIPTION
I couldn't find an implementation for isEqualTo and got an error when I tried using it so I've updated the places where I saw isEqualTo being used.